### PR TITLE
Ansible 2.9 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,8 @@ None.
 
 * `self_signed_certificate_path`: directory where the certificate will be
 * `self_signed_certificate_digest`: certificate digest, defaults to `sha512`
-* `self_signed_certificate_days_valid`: number of days the certificate will be
-  valid, defaults to `3650` (ten years)
+* `self_signed_certificate_not_after`: the point in time at which the
+  certificate stops being valid, defaults to `+3650d` (ten years)
 
 # Dependencies
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -18,5 +18,5 @@ self_signed_certificate_email: admin@{{ self_signed_certificate_FQDN | first }}
 
 self_signed_certificate_path: "{{ self_signed_certificate_key_path }}"
 self_signed_certificate_digest: "{{ self_signed_certificate_csr_digest }}"
-self_signed_certificate_days_valid: 3650
+self_signed_certificate_not_after: "+3650d"
 ...

--- a/molecule/default/Dockerfile.j2
+++ b/molecule/default/Dockerfile.j2
@@ -6,9 +6,17 @@ FROM {{ item.registry.url }}/{{ item.image }}
 FROM {{ item.image }}
 {% endif %}
 
-RUN if [ $(command -v apt-get) ]; then apt-get update && apt-get install -y python sudo bash ca-certificates && apt-get clean; \
-    elif [ $(command -v dnf) ]; then dnf makecache && dnf --assumeyes install python sudo python-devel python2-dnf bash && dnf clean all; \
-    elif [ $(command -v yum) ]; then yum makecache fast && yum install -y python sudo yum-plugin-ovl bash && sed -i 's/plugins=0/plugins=1/g' /etc/yum.conf && yum clean all; \
-    elif [ $(command -v zypper) ]; then zypper refresh && zypper install -y python sudo bash python-xml && zypper clean -a; \
+{% if item.env is defined %}
+{% for var, value in item.env.items() %}
+{% if value %}
+ENV {{ var }} {{ value }}
+{% endif %}
+{% endfor %}
+{% endif %}
+
+RUN if [ $(command -v apt-get) ]; then apt-get update && apt-get install -y python sudo bash ca-certificates iproute2 && apt-get clean; \
+    elif [ $(command -v dnf) ]; then dnf makecache && dnf --assumeyes install python sudo python-devel python*-dnf bash iproute && dnf clean all; \
+    elif [ $(command -v yum) ]; then yum makecache fast && yum install -y python sudo yum-plugin-ovl bash iproute && sed -i 's/plugins=0/plugins=1/g' /etc/yum.conf && yum clean all; \
+    elif [ $(command -v zypper) ]; then zypper refresh && zypper install -y python sudo bash python-xml iproute2 && zypper clean -a; \
     elif [ $(command -v apk) ]; then apk update && apk add --no-cache python sudo bash ca-certificates; \
-    elif [ $(command -v xbps-install) ]; then xbps-install -Syu && xbps-install -y python sudo bash ca-certificates && xbps-remove -O; fi
+    elif [ $(command -v xbps-install) ]; then xbps-install -Syu && xbps-install -y python sudo bash ca-certificates iproute2 && xbps-remove -O; fi

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -61,6 +61,6 @@
     csr_path: "{{ self_signed_certificate_csr_path }}/{{ self_signed_certificate_FQDN | first }}.csr"
     provider: selfsigned
     selfsigned_digest: "{{ self_signed_certificate_digest }}"
-    valid_in: "{{ self_signed_certificate_days_valid * 86400 }}"
+    selfsigned_not_after: "{{ self_signed_certificate_not_after }}"
     state: present
 ...

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -22,7 +22,7 @@
 
 - name: Install python OpenSSL on Fedora
   yum:
-    name: pyOpenSSL
+    name: python-cryptography
     state: present
   register: yum_result
   until: yum_result is succeeded


### PR DESCRIPTION
* Replace the `valid_in` option with `selfsigned_not_before` ahead of ansible 2.13 depreciation.
* Switch from pyOpenSSL to cryptography